### PR TITLE
feat: 1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.24.0-SNAPSHOT
-kestraVersion=[0.23,)
+version=1.0.0-SNAPSHOT
+kestraVersion=[1.0,2.0)


### PR DESCRIPTION
- Decorrelate plugin version from Kesrta version: only synchronize major version so new plugins should start at 1.0.0
- Use a minimal Kestra version of 1.0 and maximum o 2.0
