### PR TITLE
feat(ui): add conditional UI build support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'signing'
     id "com.github.ben-manes.versions" version "0.53.0"
     id 'net.researchgate.release' version '3.1.0'
+    id 'com.github.node-gradle.node' version '7.1.0'
 }
 
 def isBuildSnapshot = version.toString().endsWith("-SNAPSHOT")
@@ -201,6 +202,22 @@ release {
     git {
         requireBranch.set('main')
     }
+}
+
+// Build the UI module before packaging (only if ui/ directory exists)
+if (file('ui').exists()) {
+    tasks.register('npmInstallUI', com.github.gradle.node.npm.task.NpmTask) {
+        args = ['install']
+        workingDir = file('ui')
+    }
+
+    tasks.register('buildUI', com.github.gradle.node.npm.task.NpmTask) {
+        dependsOn 'npmInstallUI'
+        args = ['run', 'build', '--', '--outDir', '../src/main/resources/plugin-ui']
+        workingDir = file('ui')
+    }
+    processResources.dependsOn 'buildUI'
+    shadowJar.dependsOn 'buildUI'
 }
 
 /**********************************************************************************************************************\


### PR DESCRIPTION
## Summary

- Add `com.github.node-gradle.node` plugin (v7.1.0)
- Add `npmInstallUI` + `buildUI` tasks, guarded by `if (file('ui').exists())` so plugins without a UI folder are unaffected
- Uses `NpmTask` with `args = ['install']` instead of `NpmInstallTask` — the latter ignores a custom `workingDir` for input tracking and silently skips as `NO-SOURCE`

## Context

Extracted from kestra-io/plugin-gcp#598 where a `ui/` directory was added for a BigQuery topology panel. CI was failing with `vite: not found` because `node_modules` was never installed before `npm run build` ran.