### PR TITLE
fix: change default PluginCategory from TOOL to DATA

### DIFF
--- a/src/main/java/io/kestra/plugin/templates/package-info.java
+++ b/src/main/java/io/kestra/plugin/templates/package-info.java
@@ -1,7 +1,7 @@
 @PluginSubGroup(
     title = "Example plugin",
     description = "A plugin to show how to build a plugin in Kestra.",
-    categories = PluginSubGroup.PluginCategory.TOOL
+    categories = PluginSubGroup.PluginCategory.DATA
 )
 package io.kestra.plugin.templates;
 


### PR DESCRIPTION
## Why

The template shipped `categories = PluginSubGroup.PluginCategory.TOOL` as the default in `package-info.java`, but `DATA` is a far better neutral starting point: most Kestra plugins read/write/transform data, while `TOOL` implies a generic utility.

Every repo scaffolded from this template (via `kestra-plugin-scaffold` or the GitHub "Use this template" button) inherits this value silently — developers rarely notice until the plugin appears under the wrong category in the UI.

## What changed

`package-info.java`: `PluginCategory.TOOL` → `PluginCategory.DATA`