### PR TITLE
chore(deps): upgrade kestraVersion to 1.3.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.0.0-SNAPSHOT
-kestraVersion=1.2.5
+kestraVersion=2.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.0.0-SNAPSHOT
-kestraVersion=1.3.12
+kestraVersion=1.3.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.0.0-SNAPSHOT
-kestraVersion=2.0.0-SNAPSHOT
+kestraVersion=1.3.12


### PR DESCRIPTION
## Summary

- Bumps `kestraVersion` from `1.2.5` to `1.3.13`
- `1.3.13` is the first version to include `@PluginProperty(secret = true)` support ([feat(core): add @PluginProperty(secret = true) with validation for it](https://github.com/kestra-io/kestra/commit/b2fb151b0))

## Test plan

- [ ] Run `./gradlew dependencies` to verify `1.3.13` artifacts resolve
- [ ] Run `./gradlew test` to confirm tests pass against the new kestra version